### PR TITLE
add remote serialization configuration option

### DIFF
--- a/tfx_bsl/beam/run_inference.py
+++ b/tfx_bsl/beam/run_inference.py
@@ -403,7 +403,7 @@ class _RemotePredictDoFn(_BaseDoFn):
   def _prepare_instances_dict(
       self, elements: List[tf.train.Example]
   ) -> Generator[Mapping[Text, Any], None, None]:
-    """Prepare instances by converting features to dictionary"""
+    """Prepare instances by converting features to dictionary."""
     for example in elements:
       # TODO(b/151468119): support tf.train.SequenceExample
       if not isinstance(example, tf.train.Example):
@@ -425,7 +425,7 @@ class _RemotePredictDoFn(_BaseDoFn):
   def _prepare_instances_serialized(
       self, elements: List[tf.train.Example]
   ) -> Generator[Mapping[Text, Any], None, None]:
-    """Prepare instances by base64 encoding serialized examples"""
+    """Prepare instances by base64 encoding serialized examples."""
     for example in elements:
       yield {'b64': base64.b64encode(example.SerializeToString()).decode()}
 

--- a/tfx_bsl/beam/run_inference.py
+++ b/tfx_bsl/beam/run_inference.py
@@ -427,10 +427,7 @@ class _RemotePredictDoFn(_BaseDoFn):
   ) -> Generator[Mapping[Text, Any], None, None]:
     """Prepare instances by base64 encoding serialized examples"""
     for example in elements:
-      instance = {
-        'b64': base64.b64encode(example.SerializeToString()).decode()
-      }
-      yield instance
+      yield {'b64': base64.b64encode(example.SerializeToString()).decode()}
 
   def _prepare_instances(
       self, elements: List[tf.train.Example]

--- a/tfx_bsl/beam/run_inference.py
+++ b/tfx_bsl/beam/run_inference.py
@@ -432,7 +432,8 @@ class _RemotePredictDoFn(_BaseDoFn):
   def _prepare_instances(
       self, elements: List[tf.train.Example]
   ) -> Generator[Mapping[Text, Any], None, None]:
-    if self._ai_platform_prediction_model_spec.use_serialization_config:
+    if (self._ai_platform_prediction_model_spec.HasField("use_serialization_config") and
+        self._ai_platform_prediction_model_spec.use_serialization_config):
       return self._prepare_instances_serialized(elements)
     else:
       return self._prepare_instances_dict(elements)

--- a/tfx_bsl/beam/run_inference.py
+++ b/tfx_bsl/beam/run_inference.py
@@ -423,14 +423,12 @@ class _RemotePredictDoFn(_BaseDoFn):
       yield instance
 
   def _prepare_instances_serialized(
-      self, elements: List[tf.train.Example], input_name: Text
+      self, elements: List[tf.train.Example]
   ) -> Generator[Mapping[Text, Any], None, None]:
     """Prepare instances by base64 encoding serialized examples"""
     for example in elements:
       instance = {
-        input_name: {
-          'b64': base64.b64encode(example.SerializeToString()).decode()
-        }
+        'b64': base64.b64encode(example.SerializeToString()).decode()
       }
       yield instance
 
@@ -438,12 +436,7 @@ class _RemotePredictDoFn(_BaseDoFn):
       self, elements: List[tf.train.Example]
   ) -> Generator[Mapping[Text, Any], None, None]:
     if self._ai_platform_prediction_model_spec.HasField('serialization_config'):
-      input_name = (
-        self._ai_platform_prediction_model_spec.serialization_config.input_name)
-      if not input_name:
-        raise ValueError('"input_name" must be provided when using '
-                         'AIPlatformPredictionSerializationConfig')
-      return self._prepare_instances_serialized(elements, input_name)
+      return self._prepare_instances_serialized(elements)
     else:
       return self._prepare_instances_dict(elements)
 

--- a/tfx_bsl/beam/run_inference.py
+++ b/tfx_bsl/beam/run_inference.py
@@ -352,6 +352,8 @@ class _RemotePredictDoFn(_BaseDoFn):
   def __init__(self, inference_spec_type: model_spec_pb2.InferenceSpecType,
                pipeline_options: PipelineOptions):
     super(_RemotePredictDoFn, self).__init__(inference_spec_type)
+    self._ai_platform_prediction_model_spec = (
+      inference_spec_type.ai_platform_prediction_model_spec)
     self._api_client = None
 
     project_id = (
@@ -398,10 +400,10 @@ class _RemotePredictDoFn(_BaseDoFn):
     return self._api_client.projects().predict(
         name=self._full_model_name, body=body)
 
-  @classmethod
-  def _prepare_instances(
-      cls, elements: List[tf.train.Example]
+  def _prepare_instances_dict(
+      self, elements: List[tf.train.Example]
   ) -> Generator[Mapping[Text, Any], None, None]:
+    """Prepare instances by converting features to dictionary"""
     for example in elements:
       # TODO(b/151468119): support tf.train.SequenceExample
       if not isinstance(example, tf.train.Example):
@@ -413,12 +415,37 @@ class _RemotePredictDoFn(_BaseDoFn):
         if attr_name is None:
           continue
         attr = getattr(feature, attr_name)
-        values = cls._parse_feature_content(attr.value, attr_name,
-                                            cls._sending_as_binary(input_name))
+        values = self._parse_feature_content(attr.value, attr_name,
+                                             self._sending_as_binary(input_name))
         # Flatten a sequence if its length is 1
         values = (values[0] if len(values) == 1 else values)
         instance[input_name] = values
       yield instance
+
+  def _prepare_instances_serialized(
+      self, elements: List[tf.train.Example], input_name: Text
+  ) -> Generator[Mapping[Text, Any], None, None]:
+    """Prepare instances by base64 encoding serialized examples"""
+    for example in elements:
+      instance = {
+        input_name: {
+          'b64': base64.b64encode(example.SerializeToString()).decode()
+        }
+      }
+      yield instance
+
+  def _prepare_instances(
+      self, elements: List[tf.train.Example]
+  ) -> Generator[Mapping[Text, Any], None, None]:
+    if self._ai_platform_prediction_model_spec.HasField('serialization_config'):
+      input_name = (
+        self._ai_platform_prediction_model_spec.serialization_config.input_name)
+      if not input_name:
+        raise ValueError('"input_name" must be provided when using '
+                         'AIPlatformPredictionSerializationConfig')
+      return self._prepare_instances_serialized(elements, input_name)
+    else:
+      return self._prepare_instances_dict(elements)
 
   @staticmethod
   def _sending_as_binary(input_name: Text) -> bool:

--- a/tfx_bsl/beam/run_inference.py
+++ b/tfx_bsl/beam/run_inference.py
@@ -432,7 +432,7 @@ class _RemotePredictDoFn(_BaseDoFn):
   def _prepare_instances(
       self, elements: List[tf.train.Example]
   ) -> Generator[Mapping[Text, Any], None, None]:
-    if self._ai_platform_prediction_model_spec.HasField('use_serialization_config'):
+    if self._ai_platform_prediction_model_spec.use_serialization_config:
       return self._prepare_instances_serialized(elements)
     else:
       return self._prepare_instances_dict(elements)

--- a/tfx_bsl/beam/run_inference.py
+++ b/tfx_bsl/beam/run_inference.py
@@ -432,7 +432,7 @@ class _RemotePredictDoFn(_BaseDoFn):
   def _prepare_instances(
       self, elements: List[tf.train.Example]
   ) -> Generator[Mapping[Text, Any], None, None]:
-    if self._ai_platform_prediction_model_spec.HasField('serialization_config'):
+    if self._ai_platform_prediction_model_spec.HasField('use_serialization_config'):
       return self._prepare_instances_serialized(elements)
     else:
       return self._prepare_instances_dict(elements)

--- a/tfx_bsl/beam/run_inference_test.py
+++ b/tfx_bsl/beam/run_inference_test.py
@@ -597,40 +597,14 @@ class RunRemoteInferenceTest(RunInferenceFixture):
         model_name='example',
         version_name='example',
         serialization_config=model_spec_pb2.
-        AIPlatformPredictionSerializationConfig(
-          input_name='input'
-        )
+        AIPlatformPredictionSerializationConfig()
       )
     )
     remote_predict = run_inference._RemotePredictDoFn(inference_spec_type, None)
     result = list(remote_predict._prepare_instances([example]))
     self.assertEqual([
-        {
-          'input': {'b64': base64.b64encode(example.SerializeToString()).decode()}
-        },
+      {'b64': base64.b64encode(example.SerializeToString()).decode()}
     ], result)
-
-  def test_exception_raised_when_serialization_config_input_name_is_empty(self):
-    example = text_format.Parse(
-        """
-      features {
-        feature { key: "my_tensor" value { int64_list { value: [1, 2] }}}
-      }
-      """, tf.train.Example())
-    inference_spec_type = model_spec_pb2.InferenceSpecType(
-      ai_platform_prediction_model_spec=model_spec_pb2.
-      AIPlatformPredictionModelSpec(
-        project_id='example',
-        model_name='example',
-        version_name='example',
-        serialization_config=model_spec_pb2.
-        AIPlatformPredictionSerializationConfig()
-      )
-    )
-    remote_predict = run_inference._RemotePredictDoFn(inference_spec_type, None)
-
-    with self.assertRaises(ValueError):
-      result = list(remote_predict._prepare_instances([example]))
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tfx_bsl/beam/run_inference_test.py
+++ b/tfx_bsl/beam/run_inference_test.py
@@ -564,14 +564,14 @@ class RunRemoteInferenceTest(RunInferenceFixture):
     inference_spec_type = model_spec_pb2.InferenceSpecType(
       ai_platform_prediction_model_spec=model_spec_pb2.
       AIPlatformPredictionModelSpec(
-        project_id='example',
-        model_name='example',
-        version_name='example'
+        project_id='test_project',
+        model_name='test_model',
+        version_name='test_version'
       )
     )
     remote_predict = run_inference._RemotePredictDoFn(inference_spec_type, None)
     result = list(remote_predict._prepare_instances([example]))
-    self.assertEqual([
+    self.assertEqual(result, [
         {
             'x_bytes': {
                 'b64': 'QVNhOGFzZGY='
@@ -579,7 +579,7 @@ class RunRemoteInferenceTest(RunInferenceFixture):
             'x': 'JLK7ljk3',
             'y': [1, 2]
         },
-    ], result)
+    ])
 
   def test_request_serialized_example(self):
     example = text_format.Parse(
@@ -593,18 +593,18 @@ class RunRemoteInferenceTest(RunInferenceFixture):
     inference_spec_type = model_spec_pb2.InferenceSpecType(
       ai_platform_prediction_model_spec=model_spec_pb2.
       AIPlatformPredictionModelSpec(
-        project_id='example',
-        model_name='example',
-        version_name='example',
+        project_id='test_project',
+        model_name='test_model',
+        version_name='test_version',
         serialization_config=model_spec_pb2.
         AIPlatformPredictionSerializationConfig()
       )
     )
     remote_predict = run_inference._RemotePredictDoFn(inference_spec_type, None)
     result = list(remote_predict._prepare_instances([example]))
-    self.assertEqual([
+    self.assertEqual(result, [
       {'b64': base64.b64encode(example.SerializeToString()).decode()}
-    ], result)
+    ])
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tfx_bsl/beam/run_inference_test.py
+++ b/tfx_bsl/beam/run_inference_test.py
@@ -596,8 +596,7 @@ class RunRemoteInferenceTest(RunInferenceFixture):
         project_id='test_project',
         model_name='test_model',
         version_name='test_version',
-        serialization_config=model_spec_pb2.
-        AIPlatformPredictionSerializationConfig()
+        use_serialization_config=True
       )
     )
     remote_predict = run_inference._RemotePredictDoFn(inference_spec_type, None)

--- a/tfx_bsl/public/proto/model_spec.proto
+++ b/tfx_bsl/public/proto/model_spec.proto
@@ -84,18 +84,15 @@ message AIPlatformPredictionModelSpec {
   // Configures how examples are converted to API requests.
   // If not specified, example features are directly converted to json dicts according to feature type.
   oneof example_config {
-    // Use AIPlatformPredictionSerializationConfig if the model accepts a single serialized example as input.
-    AIPlatformPredictionSerializationConfig serialization_config = 4;
+    // Set use_serialization_config if the model accepts a single serialized example as input.
+    // API requests will contain the serialized example as a base64 encoded string.
+    //
+    // For example:
+    // instances = [
+    //  {'b64': '<base64 encoded serialized example 1>'},
+    //  {'b64': '<base64 encoded serialized example 2>'},
+    //  ...
+    // ]
+    bool use_serialization_config = 4;
   }
 }
-
-// An example configuration type where examples are serialized and passed to an input tensor that accepts a single string.
-// API requests will contain the serialized example as a base64 encoded string.
-//
-// For example:
-// instances = [
-//  {'b64': '<base64 encoded serialized example 1>'},
-//  {'b64': '<base64 encoded serialized example 2>'},
-//  ...
-// ]
-message AIPlatformPredictionSerializationConfig {}

--- a/tfx_bsl/public/proto/model_spec.proto
+++ b/tfx_bsl/public/proto/model_spec.proto
@@ -84,7 +84,7 @@ message AIPlatformPredictionModelSpec {
   // Configures how examples are converted to API requests.
   // If not specified, example features are directly converted to json dicts according to feature type.
   oneof example_config {
-    // Use AIPlatformPredictionSerializationConfig if the model accepts a single serialized example as input
+    // Use AIPlatformPredictionSerializationConfig if the model accepts a single serialized example as input.
     AIPlatformPredictionSerializationConfig serialization_config = 4;
   }
 }

--- a/tfx_bsl/public/proto/model_spec.proto
+++ b/tfx_bsl/public/proto/model_spec.proto
@@ -94,12 +94,8 @@ message AIPlatformPredictionModelSpec {
 //
 // For example:
 // instances = [
-//  {'<input_name>': {'b64': '<base64 encoded serialized TFExample>'}},
+//  {'b64': '<base64 encoded serialized TFExample 1>'},
+//  {'b64': '<base64 encoded serialized TFExample 2>'},
 //  ...
 // ]
-message AIPlatformPredictionSerializationConfig {
-  // Required.
-  // The name of the input tensor.
-  // This tensor should accept a single string that contains a serialized TFExample
-  string input_name = 1;
-}
+message AIPlatformPredictionSerializationConfig {}

--- a/tfx_bsl/public/proto/model_spec.proto
+++ b/tfx_bsl/public/proto/model_spec.proto
@@ -79,4 +79,27 @@ message AIPlatformPredictionModelSpec {
   // The name of the model's version.
   // If not specified, version won't be attached to the request.
   string version_name = 3;
+
+  // Optional.
+  // Configures how examples are converted to API requests.
+  // If not specified, example features are directly converted to json dicts according to feature type.
+  oneof example_config {
+    // Use AIPlatformPredictionSerializationConfig if the model accepts a single serialized TFExample as input
+    AIPlatformPredictionSerializationConfig serialization_config = 4;
+  }
+}
+
+// An example configuration type where examples are serialized and passed to an input tensor that accepts a single string.
+// API requests will contain the serialized example as a base64 encoded string.
+//
+// For example:
+// instances = [
+//  {'<input_name>': {'b64': '<base64 encoded serialized TFExample>'}},
+//  ...
+// ]
+message AIPlatformPredictionSerializationConfig {
+  // Required.
+  // The name of the input tensor.
+  // This tensor should accept a single string that contains a serialized TFExample
+  string input_name = 1;
 }

--- a/tfx_bsl/public/proto/model_spec.proto
+++ b/tfx_bsl/public/proto/model_spec.proto
@@ -84,7 +84,7 @@ message AIPlatformPredictionModelSpec {
   // Configures how examples are converted to API requests.
   // If not specified, example features are directly converted to json dicts according to feature type.
   oneof example_config {
-    // Use AIPlatformPredictionSerializationConfig if the model accepts a single serialized TFExample as input
+    // Use AIPlatformPredictionSerializationConfig if the model accepts a single serialized example as input
     AIPlatformPredictionSerializationConfig serialization_config = 4;
   }
 }
@@ -94,8 +94,8 @@ message AIPlatformPredictionModelSpec {
 //
 // For example:
 // instances = [
-//  {'b64': '<base64 encoded serialized TFExample 1>'},
-//  {'b64': '<base64 encoded serialized TFExample 2>'},
+//  {'b64': '<base64 encoded serialized example 1>'},
+//  {'b64': '<base64 encoded serialized example 2>'},
 //  ...
 // ]
 message AIPlatformPredictionSerializationConfig {}


### PR DESCRIPTION
This design adds the ability to run remote inference in tfx_bsl RunInferenceImpl with a serialized example as a tensor input. This new format conforms to the way local inference works and will allow an easier transition from local inference to remote inference.

- added example_config field to AIPlatformPredictionModelSpec proto
- restructured logic in _RemotePredictDoFn._prepare_instances to check for the example configuration and format accordingly
- added a test to demonstrate serialization functionality and ensure value assertions are raised with incomplete configurations