### PR TITLE
add tag to shared object

### DIFF
--- a/tfx_bsl/beam/shared.py
+++ b/tfx_bsl/beam/shared.py
@@ -66,8 +66,9 @@ class _SharedControlBlock(object):
   def __init__(self):
     self._lock = threading.Lock()
     self._ref = None
+    self._tag = None
 
-  def acquire(self, constructor_fn: Callable[[], Any]) -> Any:
+  def acquire(self, constructor_fn: Callable[[], Any], tag: Any = None) -> Any:
     """Acquire a reference to the object this shared control block manages.
 
     Args:
@@ -75,6 +76,9 @@ class _SharedControlBlock(object):
         present in the cache. This function should take no arguments. It should
         return an initialised object, or None if the object could not be
         initialised / constructed.
+      tag: an optional indentifier to store with the cached object. If
+        subsequent calls to acquire use different tags, the object will be
+        reloaded rather than returned from cache.
 
     Returns:
       An initialised object, either from a previous initialisation, or
@@ -83,11 +87,13 @@ class _SharedControlBlock(object):
     with self._lock:
       # self._ref is None if this is a new control block.
       # self._ref() is None if the weak reference was GCed.
-      if self._ref is None or self._ref() is None:
+      # self._tag != tag if user specifies a new identifier
+      if self._ref is None or self._ref() is None or self._tag != tag:
         result = constructor_fn()
         if result is None:
           return None
         self._ref = weakref.ref(result)
+        self._tag = tag
       else:
         result = self._ref()
     return result
@@ -161,7 +167,9 @@ class _SharedMap(object):
   def make_key(self) -> Text:
     return str(uuid.uuid1())
 
-  def acquire(self, key: Text, constructor_fn: Callable[[], Any]) -> Any:
+  def acquire(
+    self, key: Text, constructor_fn: Callable[[], Any], tag: Any = None
+  ) -> Any:
     """Acquire a reference to a Shared object.
 
     Args:
@@ -170,6 +178,9 @@ class _SharedMap(object):
         present in the cache. This function should take no arguments. It should
         return an initialised object, or None if the object could not be
         initialised / constructed.
+      tag: an optional indentifier to store with the cached object. If
+        subsequent calls to acquire use different tags, the object will be
+        reloaded rather than returned from cache.
 
     Returns:
       A reference to the initialised object, either from the cache, or
@@ -181,7 +192,7 @@ class _SharedMap(object):
         control_block = _SharedControlBlock()
         self._cache_map[key] = control_block
 
-    result = control_block.acquire(constructor_fn)
+    result = control_block.acquire(constructor_fn, tag)
 
     # Because we release the lock in between, if we acquire multiple Shareds
     # in a short time, there's no guarantee as to which one will be kept alive.
@@ -208,7 +219,7 @@ class Shared(object):
   def __init__(self):
     self._key = _shared_map.make_key()
 
-  def acquire(self, constructor_fn: Callable[[], Any]) -> Any:
+  def acquire(self, constructor_fn: Callable[[], Any], tag: Any = None) -> Any:
     """Acquire a reference to the object associated with this Shared handle.
 
     Args:
@@ -216,9 +227,12 @@ class Shared(object):
         present in the cache. This function should take no arguments. It should
         return an initialised object, or None if the object could not be
         initialised / constructed.
+      tag: an optional indentifier to store with the cached object. If
+        subsequent calls to acquire use different tags, the object will be
+        reloaded rather than returned from cache.
 
     Returns:
       A reference to an initialised object, either from the cache, or
       newly-constructed.
     """
-    return _shared_map.acquire(self._key, constructor_fn)
+    return _shared_map.acquire(self._key, constructor_fn, tag)

--- a/tfx_bsl/beam/shared_test.py
+++ b/tfx_bsl/beam/shared_test.py
@@ -247,13 +247,13 @@ class SharedTest(absltest.TestCase):
     def acquire_fn_2():
       return NamedObject('obj_2')
 
-    # with no tag, shared handle does not know when to evict objects
+    # With no tag, shared handle does not know when to evict objects
     p1 = shared1.acquire(acquire_fn_1)
     assert p1.get_name() == 'obj_1'
     p2 = shared1.acquire(acquire_fn_2)
     assert p2.get_name() == 'obj_1'
 
-    # cache eviction can be forced by specifying different tags
+    # Cache eviction can be forced by specifying different tags
     p1 = shared2.acquire(acquire_fn_1, tag='1')
     assert p1.get_name() == 'obj_1'
     p2 = shared2.acquire(acquire_fn_2, tag='2')

--- a/tfx_bsl/beam/shared_test.py
+++ b/tfx_bsl/beam/shared_test.py
@@ -237,6 +237,28 @@ class SharedTest(absltest.TestCase):
     self.assertEqual('sequence3', f3.get_name())
     self.assertEqual('sequence4', s3.get_name())
 
+  def testTagCacheEviction(self):
+    shared1 = shared.Shared()
+    shared2 = shared.Shared()
+
+    def acquire_fn_1():
+      return NamedObject('obj_1')
+
+    def acquire_fn_2():
+      return NamedObject('obj_2')
+
+    # with no tag, shared handle does not know when to evict objects
+    p1 = shared1.acquire(acquire_fn_1)
+    assert p1.get_name() == 'obj_1'
+    p2 = shared1.acquire(acquire_fn_2)
+    assert p2.get_name() == 'obj_1'
+
+    # cache eviction can be forced by specifying different tags
+    p1 = shared2.acquire(acquire_fn_1, tag='1')
+    assert p1.get_name() == 'obj_1'
+    p2 = shared2.acquire(acquire_fn_2, tag='2')
+    assert p2.get_name() == 'obj_2'
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
This PR modifies the shared object handle to store a `tag` with cached objects. By default, `shared.acquire` will keep a reference until it is garbage collected. By specifying a tag, the user can force cache eviction if the tag passed with acquire doesn't match the tag stored with the cached object.

This PR does not change public APIs but it is a prerequisite for the model streaming api where `RunInference` may need to force cache eviction of models loaded in memory.

Currently, `shared.py` is migrating to Beam core however `RunInference` still depends on the tfx-bsl version. Eventually this PR will also need to be reflected in the Beam version of `shared.py`.