### PR TITLE
Add TFXIO for reading parquet

### DIFF
--- a/tfx_bsl/tfxio/parquet_tfxio.py
+++ b/tfx_bsl/tfxio/parquet_tfxio.py
@@ -1,0 +1,133 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""TFXIO implementation for Parquet."""
+
+import copy
+from typing import Optional, List, Text, Any
+
+import apache_beam as beam
+import pyarrow as pa
+import tensorflow as tf
+from tensorflow_metadata.proto.v0 import schema_pb2
+
+from tfx_bsl.coders import csv_decoder
+
+from tfx_bsl.tfxio import dataset_options, tensor_adapter, tensor_representation_util
+from tfx_bsl.tfxio.tfxio import TFXIO
+
+
+class ParquetTFXIO(TFXIO):
+  """TFXIO implementation for Parquet."""
+
+  def __init__(self,
+               file_pattern: Text,
+               column_names: List[Text],
+               min_bundle_size: int = 0,
+               schema: Optional[schema_pb2.Schema] = None,
+               validate: Optional[bool] = True):
+    """Initializes a Parquet TFXIO.
+
+    Args:
+      file_pattern: A file glob pattern to read parquet files from.
+      column_names: List of column names to read from the parquet files.
+      min_bundle_size: the minimum size in bytes, to be considered when
+        splitting the parquet input into bundles.
+      schema: An optional TFMD Schema describing the dataset. If schema is
+        provided, it will determine the data type of the csv columns. Otherwise,
+        the each column's data type will be inferred by the csv decoder. The
+        schema should contain exactly the same features as column_names.
+      validate: Boolean flag to verify that the files exist during the pipeline
+        creation time.
+    """
+    self._file_pattern = file_pattern
+    self._column_names = column_names
+    self._min_bundle_size = min_bundle_size
+    self._validate = validate
+    self._schema = schema
+
+  def BeamSource(self, batch_size: Optional[int] = None) -> beam.PTransform:
+
+    @beam.typehints.with_input_types(Any)
+    @beam.typehints.with_output_types(pa.RecordBatch)
+    def _PTransformFn(pcoll_or_pipeline: Any):
+      """Converts raw records to RecordBatches."""
+      return (
+          pcoll_or_pipeline
+          | "ParquetBeamSource" >> beam.io.ReadFromParquetBatched(
+              file_pattern=self._file_pattern,
+              min_bundle_size=self._min_bundle_size,
+              validate=self._validate,
+              columns=self._column_names)
+          | "ToRecordBatch" >> beam.FlatMap(self._TableToRecordBatch, batch_size))
+
+    return beam.ptransform_fn(_PTransformFn)()
+
+  def RecordBatches(self, options: dataset_options.RecordBatchesOptions):
+    raise NotImplementedError
+
+  def TensorFlowDataset(
+      self,
+      options: dataset_options.TensorFlowDatasetOptions) -> tf.data.Dataset:
+    raise NotImplementedError
+
+  def _TableToRecordBatch(
+      self,
+      table: pa.Table,
+      batch_size: Optional[int] = None) -> List[pa.RecordBatch]:
+    return table.to_batches(self, max_chunksize=batch_size)
+
+  def ArrowSchema(self) -> pa.Schema:
+    schema = self._schema
+    if schema is None:
+      raise ValueError("TFMD schema not provided. Unable to derive an "
+                       "Arrow schema")
+    return csv_decoder.GetArrowSchema(self._column_names, schema)
+
+  def TensorRepresentations(self) -> tensor_adapter.TensorRepresentations:
+    result = (tensor_representation_util.GetTensorRepresentationsFromSchema(
+        self._schema))
+    if result is None:
+      result = (tensor_representation_util.InferTensorRepresentationsFromSchema(
+          self._schema))
+    return result
+
+  def _ProjectTfmdSchema(self, column_names: List[Text]) -> schema_pb2.Schema:
+    """Creates a tensorflow Schema from the current one with only the given columns"""
+
+    # The columns in the schema will remain the same, because the csv decoder
+    # will need to decode all columns no matter what.
+    result = schema_pb2.Schema()
+    result.CopyFrom(self._schema)
+
+    for feature in self._schema.feature:
+      if feature.name not in column_names:
+        result.feature.remove(feature)
+
+    return result
+
+  def _ProjectImpl(self, tensor_names: List[Text]) -> "TFXIO":
+    """Returns a projected TFXIO.
+
+    Projection is pushed down to the Parquet Beam source.
+
+    The Projected TFXIO will project the record batches, arrow schema,
+    and the tfmd schema.
+
+    Args:
+      tensor_names: The columns to project.
+    """
+    projected_schema = self._ProjectTfmdSchema(tensor_names)
+    result = copy.copy(self)
+    result._schema = projected_schema  # pylint: disable=protected-access
+    return result

--- a/tfx_bsl/tfxio/parquet_tfxio_test.py
+++ b/tfx_bsl/tfxio/parquet_tfxio_test.py
@@ -1,0 +1,253 @@
+import os
+
+import apache_beam as beam
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import tensorflow as tf
+from absl import flags
+from absl.testing import absltest
+from apache_beam.testing import util as beam_testing_util
+from google.protobuf import text_format
+from tensorflow_metadata.proto.v0 import schema_pb2
+
+from tfx_bsl.tfxio.parquet_tfxio import ParquetTFXIO
+
+FLAGS = flags.FLAGS
+_COLUMN_NAMES = ["int_feature", "float_feature", "string_feature"]
+_TELEMETRY_DESCRIPTORS = ["Some", "Component"]
+_ROWS = {
+    "int_feature": [[1], [2]],
+    "float_feature": [[2.0], [3.0]],
+    "string_feature": [["abc"], ["xyz"]]
+}
+
+_SCHEMA = text_format.Parse(
+    """
+  feature {
+  name: "int_feature"
+  type: INT
+  value_count {
+    min: 0
+    max: 2
+  }
+  }
+  feature {
+  name: "float_feature"
+  type: FLOAT
+  value_count {
+    min: 0
+    max: 2
+  }
+  }
+  feature {
+  name: "string_feature"
+  type: BYTES
+  value_count {
+    min: 0
+    max: 2
+  }
+  }
+  """, schema_pb2.Schema())
+
+_UNORDERED_SCHEMA = text_format.Parse(
+    """
+  feature {
+  name: "string_feature"
+  type: BYTES
+  value_count {
+    min: 0
+    max: 2
+  }
+  }
+  feature {
+  name: "int_feature"
+  type: INT
+  value_count {
+    min: 0
+    max: 2
+  }
+  }
+  feature {
+  name: "float_feature"
+  type: FLOAT
+  value_count {
+    min: 0
+    max: 2
+  }
+  }
+  """, schema_pb2.Schema())
+
+_EXPECTED_ARROW_SCHEMA = pa.schema([
+    pa.field("int_feature", pa.large_list(pa.int64())),
+    pa.field("float_feature", pa.large_list(pa.float32())),
+    pa.field("string_feature", pa.large_list(pa.large_binary()))
+])
+
+_EXPECTED_PROJECTED_ARROW_SCHEMA = pa.schema([
+    pa.field("int_feature", pa.large_list(pa.int64())),
+])
+
+_EXPECTED_COLUMN_VALUES = {
+    "int_feature":
+        pa.array([[1], [2]], type=pa.large_list(pa.int64())),
+    "float_feature":
+        pa.array([[2.0], [3.0]], type=pa.large_list(pa.float32())),
+    "string_feature":
+        pa.array([[b"abc"], [b"xyz"]], type=pa.large_list(pa.large_binary())),
+}
+
+
+def _WriteInputs(filename):
+  df = pd.DataFrame(_ROWS)
+  table = pa.Table.from_pandas(df)
+  pq.write_table(table, filename)
+
+
+class ParquetRecordTest(absltest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    cls._example_file = os.path.join(FLAGS.test_tmpdir, "parquettest",
+                                     "examples.parquet")
+    tf.io.gfile.makedirs(os.path.dirname(cls._example_file))
+    _WriteInputs(cls._example_file)
+
+  def testImplicitTensorRepresentations(self):
+    """Tests inferring of tensor representation."""
+    tfxio = ParquetTFXIO(file_pattern=self._example_file,
+                         column_names=_COLUMN_NAMES,
+                         schema=_UNORDERED_SCHEMA)
+    self.assertEqual(
+        {
+            "int_feature":
+                text_format.Parse(
+                    """varlen_sparse_tensor { column_name: "int_feature"}""",
+                    schema_pb2.TensorRepresentation()),
+            "float_feature":
+                text_format.Parse(
+                    """varlen_sparse_tensor { column_name: "float_feature"}""",
+                    schema_pb2.TensorRepresentation()),
+            "string_feature":
+                text_format.Parse(
+                    """varlen_sparse_tensor { column_name: "string_feature" }""",
+                    schema_pb2.TensorRepresentation()),
+        }, tfxio.TensorRepresentations())
+
+    def _AssertFn(record_batch_list):
+      self.assertLen(record_batch_list, 1)
+      record_batch = record_batch_list[0]
+      self._ValidateRecordBatch(record_batch)
+      self.assertTrue(record_batch.schema.equals(tfxio.ArrowSchema()))
+      tensor_adapter = tfxio.TensorAdapter()
+      dict_of_tensors = tensor_adapter.ToBatchTensors(record_batch)
+      self.assertLen(dict_of_tensors, 3)
+      self.assertIn("int_feature", dict_of_tensors)
+      self.assertIn("float_feature", dict_of_tensors)
+      self.assertIn("string_feature", dict_of_tensors)
+
+    with beam.Pipeline() as p:
+      record_batch_pcoll = (p | tfxio.BeamSource(batch_size=2)
+                           )  # TODO: genralize batch size
+      beam_testing_util.assert_that(record_batch_pcoll, _AssertFn)
+
+  def testExplicitTensorRepresentations(self):
+    """Tests when the tensor representation is explicitely provided in the schema."""
+    schema = schema_pb2.Schema()
+    schema.CopyFrom(_SCHEMA)
+    tensor_representations = {
+        "my_feature":
+            text_format.Parse(
+                """
+          dense_tensor {
+           column_name: "string_feature"
+           shape { dim { size: 1 } }
+           default_value { bytes_value: "abc" }
+         }""", schema_pb2.TensorRepresentation())
+    }
+    schema.tensor_representation_group[""].CopyFrom(
+        schema_pb2.TensorRepresentationGroup(
+            tensor_representation=tensor_representations))
+
+    tfxio = ParquetTFXIO(file_pattern=self._example_file,
+                         column_names=_COLUMN_NAMES,
+                         schema=schema)
+    self.assertEqual(tensor_representations, tfxio.TensorRepresentations())
+
+  def testProjection(self):
+    """Test projecting of a TFXIO."""
+    tfxio = ParquetTFXIO(file_pattern=self._example_file,
+                         column_names=_COLUMN_NAMES,
+                         schema=_UNORDERED_SCHEMA)
+
+    projected_tfxio = tfxio.Project(["int_feature"])
+
+    # The projected_tfxio has the projected schema
+    self.assertTrue(
+        projected_tfxio.ArrowSchema().equals(_EXPECTED_PROJECTED_ARROW_SCHEMA))
+
+    def _AssertFn(record_batch_list):
+      self.assertLen(record_batch_list, 1)
+      record_batch = record_batch_list[0]
+      self._ValidateRecordBatch(record_batch)
+      expected_schema = projected_tfxio.ArrowSchema()
+      self.assertTrue(
+          record_batch.schema.equals(expected_schema),
+          "actual: {}; expected: {}".format(record_batch.schema,
+                                            expected_schema))
+      tensor_adapter = projected_tfxio.TensorAdapter()
+      dict_of_tensors = tensor_adapter.ToBatchTensors(record_batch)
+      self.assertLen(dict_of_tensors, 1)
+      self.assertIn("int_feature", dict_of_tensors)
+
+    with beam.Pipeline() as p:
+      record_batch_pcoll = (p | tfxio.BeamSource(batch_size=2)
+                           )  # TODO: genralize batch size
+      beam_testing_util.assert_that(record_batch_pcoll, _AssertFn)
+
+  def testOptionalSchema(self):
+    """Tests when the schema is not provided."""
+    tfxio = ParquetTFXIO(file_pattern=self._example_file,
+                         column_names=_COLUMN_NAMES)
+
+    with self.assertRaisesRegex(ValueError, ".*TFMD schema not provided.*"):
+      tfxio.ArrowSchema()
+
+    with self.assertRaisesRegex(ValueError, ".*TFMD schema not provided.*"):
+      with beam.Pipeline() as p:
+        (p | tfxio.BeamSource(batch_size=2))
+
+  def testUnorderedSchema(self):
+    """Tests various valid schemas."""
+    tfxio = ParquetTFXIO(file_pattern=self._example_file,
+                         column_names=_COLUMN_NAMES,
+                         schema=_UNORDERED_SCHEMA)
+
+    def _AssertFn(record_batch_list):
+      self.assertLen(record_batch_list, 1)
+      record_batch = record_batch_list[0]
+      self._ValidateRecordBatch(record_batch)
+
+    with beam.Pipeline() as p:
+      record_batch_pcoll = (p | tfxio.BeamSource(batch_size=2)
+                           )  # TODO: genralize batch size
+      beam_testing_util.assert_that(record_batch_pcoll, _AssertFn)
+
+  def _ValidateRecordBatch(self, record_batch):
+    self.assertIsInstance(record_batch, pa.RecordBatch)
+    self.assertEqual(record_batch.num_rows, 2)
+    expected_schema = _EXPECTED_ARROW_SCHEMA
+    self.assertTrue(
+        record_batch.schema.equals(expected_schema),
+        "Expected: {} ; got {}".format(expected_schema, record_batch.schema))
+    for i, field in enumerate(record_batch.schema):
+      self.assertTrue(
+          record_batch.column(i).equals(_EXPECTED_COLUMN_VALUES[field.name]),
+          "Column {} did not match ({} vs {}).".format(
+              field.name, record_batch.column(i),
+              _EXPECTED_COLUMN_VALUES[field.name]))
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
These changes add a TFXIO for reading parquet files.
The implementation uses a tf.schema to describe the record schema being read, but can be further generalized to use other schemas like avro schema if this is something needed.

The implementation uses beam's `ReadFromParquetBatched` to read the files into pyarrow tables and then uses `pa.Table.to_batches` to transform them into `pa.RecordBatch`.

