### PR TITLE
Fix Install Numpy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ pip install dist/*.whl
 #### Install NumPy
 
 If NumPy is not installed on your system, install it now by following [these
-directions](https://www.scipy.org/scipylib/download.html).
+directions](https://numpy.org/install/).
 
 #### Install Bazel
 


### PR DESCRIPTION
Fixed Install NumPy instructions link to "https://numpy.org/install/"