### PR TITLE
Documentation followup PR

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     package_data={"": ["*.lib", "*.pyd", "*.so"]},
+    data_files=[("docs_reqs", ["requirements-docs.txt"])],
     zip_safe=False,
     distclass=_BinaryDistribution,
     description=(


### PR DESCRIPTION
This fixes a build error by including the `requrements-docs.txt` file as a data file