### PR TITLE
Add Support for Python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: ["cp39", "cp310", "cp311"]
+        build: ["cp39", "cp310", "cp311", "cp312"]
         os: [ubuntu-latest, macos-latest]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ setup(
         "pandas>=1.0,<2",
         'protobuf>=4.25.2,<6.0.0;python_version>="3.11"',
         'protobuf>=4.21.6,<6.0.0;python_version<"3.11"',
-        "pyarrow>=10,<11",
+        "pyarrow>=10,<15",
         "tensorflow>=2.17,<2.18",
         "tensorflow-metadata"
         + select_constraint(

--- a/setup.py
+++ b/setup.py
@@ -171,8 +171,8 @@ setup(
     # and protobuf) with TF.
     install_requires=[
         "absl-py>=0.9,<2.0.0",
-        'apache-beam[gcp]>=2.53,<3;python_version>="3.11"',
-        'apache-beam[gcp]>=2.50,<2.51;python_version<"3.11"',
+        "apache-beam[gcp]>=2.66,<3",
+        # 'apache-beam[gcp]>=2.50,<2.51;python_version<"3.11"',
         "google-api-python-client>=1.7.11,<2",
         "numpy",
         "pandas>=1.0,<2",

--- a/setup.py
+++ b/setup.py
@@ -171,14 +171,15 @@ setup(
     # and protobuf) with TF.
     install_requires=[
         "absl-py>=0.9,<2.0.0",
-        "apache-beam[gcp]>=2.66,<3",
-        # 'apache-beam[gcp]>=2.50,<2.51;python_version<"3.11"',
+        'apache-beam[gcp]>=2.66,<3;python_version>="3.11"',
+        'apache-beam[gcp]>=2.50,<2.51;python_version<"3.11"',
         "google-api-python-client>=1.7.11,<2",
         "numpy",
         "pandas>=1.0,<2",
         'protobuf>=4.25.2,<6.0.0;python_version>="3.11"',
         'protobuf>=4.21.6,<6.0.0;python_version<"3.11"',
-        "pyarrow>=14,<15",
+        'pyarrow>=10,<11;python_version<"3.11"',
+        'pyarrow>=14,<22;python_version>="3.11"',
         "tensorflow>=2.17,<2.18",
         "tensorflow-metadata"
         + select_constraint(

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,7 @@ setup(
     # and protobuf) with TF.
     install_requires=[
         "absl-py>=0.9,<2.0.0",
-        'apache-beam[gcp]>=2.66,<3;python_version>="3.11"',
+        'apache-beam[gcp]>=2.53,<3;python_version>="3.11"',
         'apache-beam[gcp]>=2.50,<2.51;python_version<"3.11"',
         "google-api-python-client>=1.7.11,<2",
         "numpy",

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ setup(
         "pandas>=1.0,<2",
         'protobuf>=4.25.2,<6.0.0;python_version>="3.11"',
         'protobuf>=4.21.6,<6.0.0;python_version<"3.11"',
-        "pyarrow>=10,<15",
+        "pyarrow>=14,<15",
         "tensorflow>=2.17,<2.18",
         "tensorflow-metadata"
         + select_constraint(


### PR DESCRIPTION
Builds and publishes Python wheels for Python 3.12

Also bumps PyArrow version to pyarrow>=14,<22 for python>=3.11