### PR TITLE
Fix cross-platform builds, PyPI upload, and Beam 2.53+ compatibility

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,3 +11,11 @@ build --host_cxxopt=-std=c++17
 build --incompatible_require_linker_input_cc_api=false
 build:macos --apple_platform_type=macos
 build:macos_arm64 --cpu=darwin_arm64
+
+# Avoid Apple ld LTO library mismatch by disabling ThinLTO on macOS
+build:macos --features=-thin_lto
+build:macos_arm64 --features=-thin_lto
+
+# Enable HAVE_UNISTD_H for zlib on macOS to prevent fdopen macro conflict
+build:macos --define=HAVE_UNISTD_H=1
+build:macos_arm64 --define=HAVE_UNISTD_H=1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1.12
         with:
           packages_dir: wheels/
-          repository_url: https://pypi.org/legacy/
+          repository_url: https://upload.pypi.org/legacy/
           # already checked, and the pkginfo/twine versions on this runner causes check to fail
           verify-metadata: true
           verbose: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ on:
       - master
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build_wheels:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,6 +2,17 @@ workspace(name = "tfx_bsl")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# Patch zlib for macOS compatibility (must come before org_tensorflow_no_deps loads zlib)
+http_archive(
+    name = "zlib",
+    build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
+    sha256 = "17e88863f3600672ab49182f217281b6fc4d3c762bde361935e436a95214d05c",
+    strip_prefix = "zlib-1.3.1",
+    urls = [
+        "https://github.com/madler/zlib/archive/v1.3.1.tar.gz",
+    ],
+)
+
 http_archive(
     name = "google_bazel_common",
     sha256 = "82a49fb27c01ad184db948747733159022f9464fc2e62da996fa700594d9ea42",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,8 +144,9 @@ test-command="pytest {project}"
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux2014"
 archs=["x86_64"]
-before-build = "yum install -y npm && npm install -g @bazel/bazelisk"
+before-build = "yum install -y npm && npm install -g @bazel/bazelisk && yum install -y hdf5-devel"
 
 
 [tool.cibuildwheel.macos]
 archs = ["arm64"]
+before-build = "brew install hdf5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ before-test="rm {project}/bazel-*"
 test-command="pytest {project}"
 
 [tool.cibuildwheel.linux]
-manylinux-x86_64-image = "manylinux2014"
+manylinux-x86_64-image = "manylinux_2_28"
 archs=["x86_64"]
 before-build = "yum install -y npm && npm install -g @bazel/bazelisk && yum install -y hdf5-devel"
 

--- a/setup.py
+++ b/setup.py
@@ -173,6 +173,7 @@ setup(
         "absl-py>=0.9,<2.0.0",
         'apache-beam[gcp]>=2.53,<3;python_version>="3.11"',
         'apache-beam[gcp]>=2.50,<2.51;python_version<"3.11"',
+        "dill>=0.3.1,<1.0.0",
         "google-api-python-client>=1.7.11,<2",
         "numpy",
         "pandas>=1.0,<2",

--- a/setup.py
+++ b/setup.py
@@ -190,9 +190,9 @@ setup(
         ),
         "tensorflow-serving-api"
         + select_constraint(
-            default="==2.17.1",
-            nightly="==2.17.1",
-            git_master="@git+https://github.com/tensorflow/serving@v2.17.1",
+            default=">=2.17.1,<3",
+            nightly=">=2.17.1.dev",
+            git_master="@git+https://github.com/tensorflow/serving@master",
         ),
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ setup(
         "dill>=0.3.1,<1.0.0",
         "google-api-python-client>=1.7.11,<2",
         "numpy",
-        "pandas>=1.0,<2",
+        "pandas",
         'protobuf>=4.25.2,<6.0.0;python_version>="3.11"',
         'protobuf>=4.21.6,<6.0.0;python_version<"3.11"',
         'pyarrow>=10,<11;python_version<"3.11"',

--- a/setup.py
+++ b/setup.py
@@ -189,9 +189,9 @@ setup(
         ),
         "tensorflow-serving-api"
         + select_constraint(
-            default=">=2.13.0,<3",
-            nightly=">=2.13.0.dev",
-            git_master="@git+https://github.com/tensorflow/serving@master",
+            default="==2.17.1",
+            nightly="==2.17.1",
+            git_master="@git+https://github.com/tensorflow/serving@v2.17.1",
         ),
     ],
     extras_require={

--- a/tfx_bsl/build_macros.bzl
+++ b/tfx_bsl/build_macros.bzl
@@ -75,9 +75,8 @@ def tfx_bsl_pybind_extension(
         prefix = name[:p + 1]
     so_file = "%s%s.so" % (prefix, sname)
     pyd_file = "%s%s.pyd" % (prefix, sname)
+    # For Python 3, the module init symbol is PyInit_<module_name>
     exported_symbols = [
-        "init%s" % sname,
-        "init_%s" % sname,
         "PyInit_%s" % sname,
     ]
 

--- a/tfx_bsl/cc/sketches/misragries_sketch.h
+++ b/tfx_bsl/cc/sketches/misragries_sketch.h
@@ -24,6 +24,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"

--- a/tfx_bsl/cc/util/status_util.h
+++ b/tfx_bsl/cc/util/status_util.h
@@ -17,6 +17,7 @@
 
 #include "absl/base/optimization.h"
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 #include "arrow/api.h"
 
 namespace tfx_bsl {

--- a/tfx_bsl/coders/csv_decoder_test.py
+++ b/tfx_bsl/coders/csv_decoder_test.py
@@ -811,9 +811,7 @@ class CSVDecoderTest(parameterized.TestCase):
                 | beam.ParDo(csv_decoder.ParseCSVLine(delimiter=","))
                 | beam.Keys()
                 | beam.CombineGlobally(
-                    csv_decoder.ColumnTypeInferrer(
-                        column_names, skip_blank_lines=False
-                    )
+                    csv_decoder.ColumnTypeInferrer(column_names, skip_blank_lines=False)
                 )
             )
             beam_test_util.assert_that(result, lambda _: None)

--- a/tfx_bsl/coders/csv_decoder_test.py
+++ b/tfx_bsl/coders/csv_decoder_test.py
@@ -802,21 +802,23 @@ class CSVDecoderTest(parameterized.TestCase):
         input_lines = ["1,2.0,hello", "5,12.34"]
         column_names = ["int_feature", "float_feature", "str_feature"]
         with self.assertRaisesRegex(  # pylint: disable=g-error-prone-assert-raises
-            ValueError, ".*Columns do not match specified csv headers.*"
+            (ValueError, RuntimeError), ".*Columns do not match specified csv headers.*"
         ):
-            with beam.Pipeline() as p:
-                result = (
-                    p
-                    | beam.Create(input_lines, reshuffle=False)
-                    | beam.ParDo(csv_decoder.ParseCSVLine(delimiter=","))
-                    | beam.Keys()
-                    | beam.CombineGlobally(
-                        csv_decoder.ColumnTypeInferrer(
-                            column_names, skip_blank_lines=False
-                        )
+            p = beam.Pipeline()
+            result = (
+                p
+                | beam.Create(input_lines, reshuffle=False)
+                | beam.ParDo(csv_decoder.ParseCSVLine(delimiter=","))
+                | beam.Keys()
+                | beam.CombineGlobally(
+                    csv_decoder.ColumnTypeInferrer(
+                        column_names, skip_blank_lines=False
                     )
                 )
-                beam_test_util.assert_that(result, lambda _: None)
+            )
+            beam_test_util.assert_that(result, lambda _: None)
+            pipeline_result = p.run()
+            pipeline_result.wait_until_finish()
 
     def test_invalid_schema_type(self):
         input_lines = ["1"]

--- a/tfx_bsl/telemetry/collection_test.py
+++ b/tfx_bsl/telemetry/collection_test.py
@@ -29,14 +29,14 @@ class CollectionTest(absltest.TestCase):
         )
         expected_num_bytes = inputs.nbytes
 
-        with beam.Pipeline(**test_helpers.make_test_beam_pipeline_kwargs()) as p:
-            _ = (
-                p
-                | beam.Create([inputs])
-                | collection.TrackRecordBatchBytes("TestNamespace", "num_bytes_count")
-            )
-
+        p = beam.Pipeline(**test_helpers.make_test_beam_pipeline_kwargs())
+        _ = (
+            p
+            | beam.Create([inputs])
+            | collection.TrackRecordBatchBytes("TestNamespace", "num_bytes_count")
+        )
         pipeline_result = p.run()
+        pipeline_result.wait_until_finish()
         result_metrics = pipeline_result.metrics()
         actual_counter = result_metrics.query(
             beam.metrics.metric.MetricsFilter().with_name("num_bytes_count")
@@ -74,16 +74,16 @@ class CollectionTest(absltest.TestCase):
             "ragged_tensor": num_ragged_tensors,
         }
 
-        with beam.Pipeline(**test_helpers.make_test_beam_pipeline_kwargs()) as p:
-            _ = (
-                p
-                | beam.Create([tensor_representations])
-                | collection.TrackTensorRepresentations(
-                    counter_namespace="TestNamespace"
-                )
+        p = beam.Pipeline(**test_helpers.make_test_beam_pipeline_kwargs())
+        _ = (
+            p
+            | beam.Create([tensor_representations])
+            | collection.TrackTensorRepresentations(
+                counter_namespace="TestNamespace"
             )
-
+        )
         pipeline_result = p.run()
+        pipeline_result.wait_until_finish()
         result_metrics = pipeline_result.metrics()
         for kind, expected_count in expected_counters.items():
             actual_counter = result_metrics.query(

--- a/tfx_bsl/telemetry/collection_test.py
+++ b/tfx_bsl/telemetry/collection_test.py
@@ -78,9 +78,7 @@ class CollectionTest(absltest.TestCase):
         _ = (
             p
             | beam.Create([tensor_representations])
-            | collection.TrackTensorRepresentations(
-                counter_namespace="TestNamespace"
-            )
+            | collection.TrackTensorRepresentations(counter_namespace="TestNamespace")
         )
         pipeline_result = p.run()
         pipeline_result.wait_until_finish()


### PR DESCRIPTION
## Problem

Building and publishing tfx-bsl fails on both Linux and macOS due to multiple issues:

1. **macOS linker error**: ThinLTO assumes Apple's `libLTO.dylib`, causing failures with conda-provided compilers
2. **zlib compilation**: Macro conflicts between zlib 1.2.11 and modern macOS SDK headers
3. **Module symbols**: Python 2-era extension symbols cause linker failures on Python 3
4. **HDF5 dependency**: Missing system library for h5py (transitive dependency) on Python 3.10+ and 3.11+
5. **Test failures**: Apache Beam 2.53+ metrics API changes break telemetry tests on Python 3.11+
6. **Missing dependencies**: `dill` not explicitly listed despite being required
7. **C++ compilation**: Missing `absl/strings/str_cat.h` header causes build failure
8. **PyPI upload failure**: Incorrect repository URL (`pypi.org/legacy/` instead of `upload.pypi.org/legacy/`) causes 404 errors

## Solution

This PR addresses all build and test failures across platforms:

### Changes

#### .bazelrc
- Disable ThinLTO on macOS/macOS arm64 to avoid linker errors with conda compilers
- Define `HAVE_UNISTD_H=1` for zlib compatibility with modern macOS headers

#### .github/workflows/build.yml
- Add `workflow_dispatch` trigger to enable manual PyPI uploads
- Fix PyPI upload repository URL from `https://pypi.org/legacy/` to `https://upload.pypi.org/legacy/`
- Resolves 404 errors when publishing packages to PyPI
- **Successfully tested**: Package published to PyPI (https://pypi.org/project/tfx-bsl-czgdp1807/1.18.0.dev0/)
- Verified in fork CI run: https://github.com/czgdp1807/tfx-bsl/actions/runs/21641775927/job/62386135354#logs

#### WORKSPACE
- Update zlib to version 1.3.1 (from implicit 1.2.11)
- Define explicit `http_archive` for zlib before tensorflow dependency loads it
- Prevents fdopen macro conflicts with macOS SDK `_stdio.h`

#### pyproject.toml
- **Linux**: Upgrade from `manylinux2014` to `manylinux_2_28` for HDF5 >= 1.10.7
- **Linux**: Add `hdf5-devel` installation in `before-build` step
- **macOS**: Add `brew install hdf5` in `before-build` step
- Fixes h5py build failures for Python 3.10+ on Linux and Python 3.11+ on all platforms

#### setup.py
- Add explicit `dill>=0.3.1,<1.0.0` dependency (required by Apache Beam but not declared)
- Pin `tensorflow-serving-api` to `>=2.17.1,<3` (was `>=2.13.0,<3`)
- Updated all selectors: default, and nightly
- Ensures consistent protobuf/grpc versions across all build configurations

#### tfx_bsl/build_macros.bzl
- Remove Python 2 module initialization symbols (`init_*`, `init*`)
- Keep only `PyInit_<module>` for Python 3 compatibility
- Fixes undefined symbol errors during extension module linking

#### tfx_bsl/cc/sketches/misragries_sketch.h
- Add missing `#include "absl/strings/str_cat.h"` header
- Fixes compilation error: `no member named 'StrCat' in namespace 'absl'`

#### tfx_bsl/telemetry/collection_test.py
- Update tests for Apache Beam 2.53+ metrics API compatibility
- Remove `with` context manager pattern and explicitly call `pipeline_result.wait_until_finish()`
- Ensures metrics are committed before assertions run

#### tfx_bsl/coders/csv_decoder_test.py
- Update exception handling for Apache Beam 2.53+ compatibility
- Accept both `ValueError` and `RuntimeError` (newer Beam wraps exceptions)
- Add explicit `pipeline_result.wait_until_finish()` call

## Testing

**Local testing**: macOS arm64, Python 3.12, Bazel 6.5.0
- Build completes without compiler or linker errors
- All previously failing tests now pass
- Package installs via `pip install -e ".[test]"`

**CI validation**: All checks passing on fork
- https://github.com/czgdp1807/tfx-bsl/pull/1
- Tested on: Python 3.9, 3.10, 3.11, 3.12 on both ubuntu-latest and macos-latest
- Previously failing test suite (refer - https://github.com/czgdp1807/tfx-bsl/actions/runs/21594219988) now passes completely

**PyPI Upload verification**: Tested and working
- Successfully published package to PyPI
- Fork CI run: https://github.com/czgdp1807/tfx-bsl/actions/runs/21641775927/job/62386135354#logs
- Published package: https://pypi.org/project/tfx-bsl-czgdp1807/1.18.0.dev0/
- The `workflow_dispatch` trigger enables manual PyPI uploads for future releases

## Impact

- Enables macOS arm64 builds with conda environments
- Fixes CI failures on Python 3.10+ (Linux) and 3.11+ (all platforms)
- Resolves HDF5 dependency issues for h5py transitive dependency
- Updates tests for Apache Beam 2.53+ compatibility
- Maintains Python 3.9+ compatibility
- Drops Python 2 support (already EOL)

## Root Cause Analysis

The CI failures emerged because,

- 6 months ago: older package versions didn't require h5py or use Beam 2.53+
- Today: same commit resolves to newer package versions that:
  - Pull in h5py as transitive dependency (requires HDF5 C library)
  - Use Apache Beam 2.53+ with changed metrics API behavior

This is why Python 3.9 still passes (uses older dependency ranges) while 3.10+ fails.