### PR TITLE
Python 3.12 build, remove python 2 init symbols

### DIFF
--- a/tfx_bsl/build_macros.bzl
+++ b/tfx_bsl/build_macros.bzl
@@ -76,8 +76,6 @@ def tfx_bsl_pybind_extension(
     so_file = "%s%s.so" % (prefix, sname)
     pyd_file = "%s%s.pyd" % (prefix, sname)
     exported_symbols = [
-        "init%s" % sname,
-        "init_%s" % sname,
         "PyInit_%s" % sname,
     ]
 


### PR DESCRIPTION
Build was failing in my environment on python 3.12.4 before this fix.  Open to any suggestions/modifications.