### PR TITLE
ci: declare contents:read on nightly wheels workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,6 +23,9 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build_wheels:
     name: Build Wheels (Nightly)


### PR DESCRIPTION
The nightly `Build tfx-bsl Nightly` workflow builds wheels for the cp310-cp313 / ubuntu+macos matrix via `pypa/cibuildwheel@v2.23.3` and uploads them as `actions/upload-artifact` artifacts. No GitHub API write (artifact upload in v4 doesn't require explicit permissions), no comment on PRs, no push to the repo.

This patch sets `permissions: contents: read` at workflow scope. It matches the per-job permission block already in `build.yml` (`id-token: write` for trusted publishing of the release wheels) -- both workflows now declare the minimum the steps actually use.

With explicit scope:

- the workflow token can't be widened by a future change to the repo default
- the SLSA / OpenSSF Scorecard `Token-Permissions` check passes for this file
- a hypothetical compromise of `pypa/cibuildwheel` or `actions/upload-artifact` (cf. tj-actions/changed-files CVE-2025-30066) stays boxed in read-only.

`ci-lint.yml` is the other workflow that doesn't declare permissions, but it's 21 lines and below the noise floor for a separate PR.

No behavioural change.