### PR TITLE
Post-release alignment: bump version to 1.22.0.dev and archive 1.21.0 release notes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Upload to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1.12
         with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: wheels/
           repository_url: https://pypi.org/legacy/
           # already checked, and the pkginfo/twine versions on this runner causes check to fail

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TFX Basic Shared Libraries
 
-[![Python](https://img.shields.io/badge/python%7C3.9%7C3.10%7C3.11-blue)](https://github.com/tensorflow/tfx-bsl)
+[![Python](https://img.shields.io/badge/python%7C3.10%7C3.11%7C3.12%7C3.13-blue)](https://github.com/tensorflow/tfx-bsl)
 [![PyPI](https://badge.fury.io/py/tfx-bsl.svg)](https://badge.fury.io/py/tfx-bsl)
 
 TFX Basic Shared Libraries (`tfx_bsl`) contains libraries shared by many
@@ -105,7 +105,8 @@ combinations may also work.
 
 tfx-bsl                                                                         | apache-beam[gcp] | pyarrow  | tensorflow        | tensorflow-metadata | tensorflow-serving-api |
 ------------------------------------------------------------------------------- | -----------------| ---------|-------------------|---------------------|------------------------|
-[GitHub master](https://github.com/tensorflow/tfx-bsl/blob/master/RELEASE.md)   | 2.64.0           | 10.0.1   | nightly (2.x)     | 1.17.1              | 2.17.1                 |
+[GitHub master](https://github.com/tensorflow/tfx-bsl/blob/master/RELEASE.md)   | 2.64.0           | 14.0.1   | nightly (2.x)     | 1.21.0              | 2.19.0                 |
+[1.21.0](https://github.com/tensorflow/tfx-bsl/blob/v1.21.0/RELEASE.md)         | 2.64.0           | 14.0.1   | 2.21              | 1.21.0              | 2.19.0                 |
 [1.17.1](https://github.com/tensorflow/tfx-bsl/blob/v1.17.1/RELEASE.md)         | 2.64.0           | 10.0.1   | 2.17              | 1.17.1              | 2.17.1                 |
 [1.17.0](https://github.com/tensorflow/tfx-bsl/blob/v1.17.0/RELEASE.md)         | 2.64.0           | 10.0.1   | 2.17              | 1.17.1              | 2.17.1                 |
 [1.16.1](https://github.com/tensorflow/tfx-bsl/blob/v1.16.1/RELEASE.md)         | 2.59.0           | 10.0.1   | 2.16              | 1.16.1              | 2.16.1                 |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,9 +4,20 @@
 
 ## Bug Fixes and Other Changes
 
+## Breaking Changes
+
+## Deprecations
+
+# Version 1.21.0
+
+## Major Features and Improvements
+
+*   N/A
+
+## Bug Fixes and Other Changes
+
 *   Added support for Python 3.12 and Python 3.13, and dropped support for Python 3.9.
 *   Depends on `tensorflow>=2.21,<2.22`.
-
 *   Depends on `protobuf>=6.0.0,<7.0.0`.
 *   Removed `numpy<2` restriction and required `pandas>=2.0` to support NumPy 2.x.
 *   Bumped the minimum bazel version required to build `tfx_bsl` to 7.7.0.
@@ -16,8 +27,11 @@
 
 ## Breaking Changes
 
+*   N/A
 
 ## Deprecations
+
+*   N/A
 
 # Version 1.17.1
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -135,11 +135,11 @@ http_archive(
     urls = ["https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz"],
 )
 
-TFMD_COMMIT = "d3194a388344cb7a10d42b2a7c01bf384f3d1741"  # aligned with TF 2.21.0 dependencies
+TFMD_COMMIT = "da17f4557749ae122284c5be3e43a2f211d3e6e2"  # 1.21.0
 
 http_archive(
     name = "com_github_tensorflow_metadata",
-    sha256 = "73195ecfc4801e987ae00f891965cbca0ef5849fe1cf6ae792447781a33d6520",
+    sha256 = "ea10e1291dc8acbff804461845c983823ef6ee25e16bc0199c4596d08de430e9",
     strip_prefix = "metadata-%s" % TFMD_COMMIT,
     urls = ["https://github.com/tensorflow/metadata/archive/%s.zip" % TFMD_COMMIT],
 )

--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ setup(
         "tensorflow-metadata"
         + select_constraint(
             default="@git+https://github.com/tensorflow/metadata@master",
-            nightly=">=1.18.0.dev",
+            nightly=">=1.21.0.dev",
             git_master="@git+https://github.com/tensorflow/metadata@master",
         ),
         "tensorflow-serving-api"

--- a/tfx_bsl/version.py
+++ b/tfx_bsl/version.py
@@ -14,4 +14,4 @@
 """Contains the version string of tfx_bsl."""
 
 # Note that setup.py uses this version.
-__version__ = "1.18.0.dev"
+__version__ = "1.22.0.dev"


### PR DESCRIPTION
### This PR is for Post-Release Alignment with Release branch

* **Development Version**: Bumped `tfx_bsl/version.py` forward to `1.22.0.dev`.
* **Nightly Selector**: Aligned `tensorflow-metadata` nightly selector constraint to `>=1.21.0.dev` in `setup.py`.
* **WORKSPACE Alignment**: Pinned `com_github_tensorflow_metadata` to the stable `1.21.0` release commit (`da17f4557749ae122284c5be3e43a2f211d3e6e2`).
* **Synced Documentation & CI**: Added the `1.21.0` release row and aligned the `GitHub master` tracking entries in `README.md`, and mapped `PYPI_API_TOKEN` authentication in `.github/workflows/build.yml`.
* **Release Notes Archiving**: Pushed the finalized `# Version 1.21.0` notes into permanent record and placed an empty `# Current Version (not yet released; still in development)` block at the top of `RELEASE.md`.
